### PR TITLE
feat: better types from params

### DIFF
--- a/src/__tests__/memoize.test.ts
+++ b/src/__tests__/memoize.test.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 import IORedis from 'ioredis'
-import { AsyncFunc } from '../strategies/memoize'
+import { AsyncFunc } from '../types/common'
 import { getMemoize, useAsDefault } from '../index'
 import { AvailableCacheLayer } from '../types/layer'
 import { CacheLayerManager } from '../layers/manager'
@@ -25,7 +25,7 @@ test('should correctly store fn result inside the cache', async t => {
     return {}
   }
 
-  const patched = getMemoize<Object>(asyncTest, {
+  const patched = getMemoize<typeof asyncTest>(asyncTest, {
     layerConfigs: {
       [AvailableCacheLayer.MEMORY]: {
         ttl: 5000,
@@ -51,7 +51,7 @@ test('should correctly fetch from cache if the result is already there', async t
     return {}
   }
 
-  const patched = getMemoize<Object>(asyncTest, {
+  const patched = getMemoize<typeof asyncTest>(asyncTest, {
     layerConfigs: {
       [AvailableCacheLayer.MEMORY]: {
         ttl: 5000,
@@ -74,11 +74,11 @@ test('should correctly fetch from cache if the result is already there', async t
 })
 
 test('should compute have two different key for different invokation', async t => {
-  const asyncTest = async () => {
+  const asyncTest = async (t?: number) => {
     return {}
   }
 
-  const patched = getMemoize<Object>(asyncTest, {
+  const patched = getMemoize<typeof asyncTest>(asyncTest, {
     layerConfigs: {
       [AvailableCacheLayer.MEMORY]: {
         ttl: 5000,
@@ -108,7 +108,7 @@ test('should correctly set prefix as function name', async t => {
     return {}
   }
 
-  const patched = getMemoize<Object>(asyncTest, {
+  const patched = getMemoize<typeof asyncTest>(asyncTest, {
     layerConfigs: {
       [AvailableCacheLayer.REDIS]: {
         ttl: 5000,
@@ -144,7 +144,7 @@ test('should correctly set a custom prefix', async t => {
     ]
   })
 
-  const patched = getMemoize<Object>(asyncTest, {
+  const patched = getMemoize<typeof asyncTest>(asyncTest, {
     layerConfigs: {
       [AvailableCacheLayer.REDIS]: {
         prefix: 'myPrefix'
@@ -160,7 +160,7 @@ test('should correctly set a custom prefix', async t => {
 })
 
 test('should correctly use computeHash', async t => {
-  const asyncTest = async () => {
+  const asyncTest = async (test: string, foo?: number) => {
     return {}
   }
 
@@ -176,7 +176,7 @@ test('should correctly use computeHash', async t => {
     ]
   })
 
-  const patched = getMemoize<Object>(asyncTest, {
+  const patched = getMemoize<typeof asyncTest>(asyncTest, {
     layerConfigs: {
       [AvailableCacheLayer.REDIS]: {
         prefix: 'myPrefix2'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { CacheLayerManagerOptions } from './layers/manager'
 import { currentConfig } from './utils/config'
-import { memoizeFunction, AsyncFunc, MemoizeFunctionOptions } from './strategies/memoize'
+import { memoizeFunction, MemoizeFunctionOptions } from './strategies/memoize'
 import { Cache } from './strategies/store'
+import { AsyncFunc, Func } from './types/common'
 
 type NestedPartial<T> = {
-  [K in keyof T]?: T[K] extends Array<infer R> ? Array<NestedPartial<R>> : NestedPartial<T[K]>
+  [K in keyof T]?: T[K] extends Array<infer R> ? Array<NestedPartial<R>> : T[K] extends Function ? T[K] : NestedPartial<T[K]>
 }
 
 export const useAsDefault = (options: CacheLayerManagerOptions) => {
@@ -35,10 +36,10 @@ export const getStore = (options?: NestedPartial<CacheLayerManagerOptions>) => {
  *  config given to `useAsDefault`
  */
 export const getMemoize = <T extends object | string>(
-  fn: AsyncFunc<T>,
-  options?: NestedPartial<MemoizeFunctionOptions>
+  fn: Func<T>,
+  options?: NestedPartial<MemoizeFunctionOptions<T>>
 ) => {
-  return memoizeFunction<T>(fn, options as MemoizeFunctionOptions)
+  return memoizeFunction<T>(fn, options as MemoizeFunctionOptions<T>)
 }
 
 /**
@@ -49,11 +50,11 @@ export const getMemoize = <T extends object | string>(
  *  config given to `useAsDefault`
  */
 export const Memoize = <T extends object | string>(
-  options?: NestedPartial<MemoizeFunctionOptions>
+  options?: NestedPartial<MemoizeFunctionOptions<T>>
 ) => {
   return (target: Object, propertyKey: string, descriptor: TypedPropertyDescriptor<AsyncFunc<T>>) => {
     if (descriptor.value !== undefined) {
-      descriptor.value = getMemoize<T>(descriptor.value, options)
+      descriptor.value = getMemoize<T>(descriptor.value as Func<T>, options)
     } else {
       throw new Error('Memoize decorator only available for async function.')
     }

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,4 +1,15 @@
+// Used to get parameters type from patched function
 export type Parameters<T> = T extends (...args: infer T) => any ? T : unknown[]
-export type ReturnType<T> = T extends (...args: any[]) => infer T ? T : string | object
-export type Func<T> = (...args: Parameters<T>) => ReturnType<T>
+// Used to get return type from patched function used for type our memoize function
+// (we remove the promise, the original function should be an async function)
+export type ReturnType<T> = T extends (...args: any[]) => infer T ? Unpromisify<T> : string | object
+// Used to type the patched function (with the promise)
+export type OriginalReturnType<T> = Promise<ReturnType<T>>
+// Type of the original function with params and promise as result
+export type Func<T> = (...args: Parameters<T>) => OriginalReturnType<T>
+// Type of our memoize function with original params and promise with original returns types
+// we need to remove promise from the original function and set it again to be sure to only
+// have one level of promise (avoid Promise<Promise<string>>)
 export type AsyncFunc<T> = (...args: Parameters<T>) => Promise<ReturnType<T>>
+// Used to remove promise from a type
+export type Unpromisify<T> = T extends Promise<infer R> ? R : T

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,4 @@
+export type Parameters<T> = T extends (...args: infer T) => any ? T : unknown[]
+export type ReturnType<T> = T extends (...args: any[]) => infer T ? T : string | object
+export type Func<T> = (...args: Parameters<T>) => ReturnType<T>
+export type AsyncFunc<T> = (...args: Parameters<T>) => Promise<ReturnType<T>>


### PR DESCRIPTION
```ts
  const asyncTest = async (test: string, foo?: number) => {
    return {}
  }
```

```ts
(property) computeHash?: (args: [string, number?]) => string
```

```ts
const patched: (test: string, foo?: number) => Promise<{}>
```